### PR TITLE
feat: pressing delete removes higlighted entry

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -386,6 +386,19 @@ const ClipboardIndicator = GObject.registerClass({
         }
     }
 
+    _findNextMenuItem (currentMenutItem) {
+        let currentIndex = this.clipItemsRadioGroup.indexOf(currentMenutItem)
+
+        for (let i = currentIndex +1; i < this.clipItemsRadioGroup.length; i++){
+            let menuItem  = this.clipItemsRadioGroup[i]
+            if(menuItem.actor.visible) {
+                return menuItem
+            }
+        }
+
+        return null
+    }
+
     _addEntry (entry, autoSelect, autoSetClip) {
         let menuItem = new PopupMenu.PopupMenuItem('');
 
@@ -394,10 +407,18 @@ const ClipboardIndicator = GObject.registerClass({
         menuItem.clipContents = entry.getStringValue();
         menuItem.radioGroup = this.clipItemsRadioGroup;
         menuItem.buttonPressId = menuItem.connect('activate',
-            autoSet => this._onMenuItemSelectedAndMenuClose(menuItem, autoSet));
+            autoSet => this._onMenuItemSelectedAndMenuClose(menuItem, autoSet))
         menuItem.actor.connect('key-press-event', (actor, event) => {
             if(event.get_key_symbol() === Clutter.KEY_Delete) {
                 this._removeEntry(menuItem, 'delete')
+
+                let nextMenuItem = this._findNextMenuItem(menuItem)
+
+                if (nextMenuItem) {
+                    nextMenuItem.actor.grab_key_focus()
+                } else {
+                    this.searchEntry.grab_key_focus()
+                }
             }
         })
 

--- a/extension.js
+++ b/extension.js
@@ -387,16 +387,16 @@ const ClipboardIndicator = GObject.registerClass({
     }
 
     _findNextMenuItem (currentMenutItem) {
-        let currentIndex = this.clipItemsRadioGroup.indexOf(currentMenutItem)
+        let currentIndex = this.clipItemsRadioGroup.indexOf(currentMenutItem);
 
         for (let i = currentIndex +1; i < this.clipItemsRadioGroup.length; i++){
-            let menuItem  = this.clipItemsRadioGroup[i]
+            let menuItem  = this.clipItemsRadioGroup[i];
             if(menuItem.actor.visible) {
-                return menuItem
+                return menuItem;
             }
         }
 
-        return null
+        return null;
     }
 
     _addEntry (entry, autoSelect, autoSetClip) {
@@ -407,17 +407,17 @@ const ClipboardIndicator = GObject.registerClass({
         menuItem.clipContents = entry.getStringValue();
         menuItem.radioGroup = this.clipItemsRadioGroup;
         menuItem.buttonPressId = menuItem.connect('activate',
-            autoSet => this._onMenuItemSelectedAndMenuClose(menuItem, autoSet))
+            autoSet => this._onMenuItemSelectedAndMenuClose(menuItem, autoSet));
         menuItem.actor.connect('key-press-event', (actor, event) => {
             if(event.get_key_symbol() === Clutter.KEY_Delete) {
-                this._removeEntry(menuItem, 'delete')
+                this._removeEntry(menuItem, 'delete');
 
-                let nextMenuItem = this._findNextMenuItem(menuItem)
+                let nextMenuItem = this._findNextMenuItem(menuItem);
 
                 if (nextMenuItem) {
-                    nextMenuItem.actor.grab_key_focus()
+                    nextMenuItem.actor.grab_key_focus();
                 } else {
-                    this.privateModeMenuItem.actor.grab_key_focus()
+                    this.privateModeMenuItem.actor.grab_key_focus();
                 }
             }
         })

--- a/extension.js
+++ b/extension.js
@@ -395,6 +395,11 @@ const ClipboardIndicator = GObject.registerClass({
         menuItem.radioGroup = this.clipItemsRadioGroup;
         menuItem.buttonPressId = menuItem.connect('activate',
             autoSet => this._onMenuItemSelectedAndMenuClose(menuItem, autoSet));
+        menuItem.actor.connect('key-press-event', (actor, event) => {
+            if(event.get_key_symbol() === Clutter.KEY_Delete) {
+                this._removeEntry(menuItem, 'delete')
+            }
+        })
 
         this._setEntryLabel(menuItem);
         this.clipItemsRadioGroup.push(menuItem);

--- a/extension.js
+++ b/extension.js
@@ -417,7 +417,7 @@ const ClipboardIndicator = GObject.registerClass({
                 if (nextMenuItem) {
                     nextMenuItem.actor.grab_key_focus()
                 } else {
-                    this.searchEntry.grab_key_focus()
+                    this.privateModeMenuItem.actor.grab_key_focus()
                 }
             }
         })

--- a/extension.js
+++ b/extension.js
@@ -386,6 +386,19 @@ const ClipboardIndicator = GObject.registerClass({
         }
     }
 
+    _findNextMenuItem (currentMenutItem) {
+        let currentIndex = this.clipItemsRadioGroup.indexOf(currentMenutItem)
+
+        for (let i = currentIndex +1; i < this.clipItemsRadioGroup.length; i++){
+            let menuItem  = this.clipItemsRadioGroup[i]
+            if(menuItem.actor.visible) {
+                return menuItem
+            }
+        }
+
+        return null
+    }
+
     _addEntry (entry, autoSelect, autoSetClip) {
         let menuItem = new PopupMenu.PopupMenuItem('');
 
@@ -394,7 +407,20 @@ const ClipboardIndicator = GObject.registerClass({
         menuItem.clipContents = entry.getStringValue();
         menuItem.radioGroup = this.clipItemsRadioGroup;
         menuItem.buttonPressId = menuItem.connect('activate',
-            autoSet => this._onMenuItemSelectedAndMenuClose(menuItem, autoSet));
+            autoSet => this._onMenuItemSelectedAndMenuClose(menuItem, autoSet))
+        menuItem.actor.connect('key-press-event', (actor, event) => {
+            if(event.get_key_symbol() === Clutter.KEY_Delete) {
+                this._removeEntry(menuItem, 'delete')
+
+                let nextMenuItem = this._findNextMenuItem(menuItem)
+
+                if (nextMenuItem) {
+                    nextMenuItem.actor.grab_key_focus()
+                } else {
+                    this.privateModeMenuItem.actor.grab_key_focus()
+                }
+            }
+        })
 
         this._setEntryLabel(menuItem);
         this.clipItemsRadioGroup.push(menuItem);


### PR DESCRIPTION
1. Pressing the delete button when on a highlighted entry removes the entry
2. After the entry is removed the focus shifts to the next item and if empty then to the private

Tested it on GNOME OS Nightly ( via GNOME Boxes ) 